### PR TITLE
Adjust roaster size and contact section layout

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -98,7 +98,8 @@ nav a {
 
 .roaster-img {
   margin-top: 2em;
-  max-width: 100%;
+  width: 100%;
+  max-width: 400px;
   height: auto;
 }
 
@@ -113,6 +114,8 @@ nav a {
 .products, .contact {
   flex: 1;
   min-width: 280px;
+  max-width: 480px;
+  margin: 0 auto;
 }
 
 .products h2, .contact h2 {


### PR DESCRIPTION
## Summary
- resize `roaster-img` to prevent it from stretching
- limit width of the "Our Coffees" and "Contact Us" columns so they line up neatly on larger screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c17c56ed883269b337d299a2c03d3