### PR TITLE
Add contact info footer across site

### DIFF
--- a/about.html
+++ b/about.html
@@ -35,6 +35,7 @@
       <p>We started Green Bean Coffee with a simple goal: deliver freshly roasted
       coffee to our community. Every bean is sourced with care and roasted to
       highlight its unique flavors.</p>
+      <p>Our founder studied at York College of Pennsylvania and brings that dedication to quality into every roast.</p>
     </div>
     <div class="column">
       <h2>OUR PHILOSOPHY</h2>
@@ -42,6 +43,14 @@
       and building long lasting relationships with our farmers and customers.</p>
     </div>
   </section>
+
+  <footer class="footer">
+    <p><strong>Categories:</strong> Coffee Shop</p>
+    <p><strong>Address:</strong> 100 S Beaver St, York, PA, United States, 17401</p>
+    <p><strong>Phone:</strong> (717) 848-4070</p>
+    <p><strong>Email:</strong> <a href="mailto:coffee.gbrc@gmail.com">coffee.gbrc@gmail.com</a></p>
+    <p><strong>Studied at:</strong> York College of Pennsylvania</p>
+  </footer>
   <script src="script.js"></script>
   </body>
   </html>

--- a/contact.html
+++ b/contact.html
@@ -34,6 +34,14 @@
       </form>
     </div>
   </section>
+
+  <footer class="footer">
+    <p><strong>Categories:</strong> Coffee Shop</p>
+    <p><strong>Address:</strong> 100 S Beaver St, York, PA, United States, 17401</p>
+    <p><strong>Phone:</strong> (717) 848-4070</p>
+    <p><strong>Email:</strong> <a href="mailto:coffee.gbrc@gmail.com">coffee.gbrc@gmail.com</a></p>
+    <p><strong>Studied at:</strong> York College of Pennsylvania</p>
+  </footer>
   <script src="script.js"></script>
   </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,15 @@
         <button type="submit">SEND</button>
       </form>
     </div>
-</section>
-<script src="script.js"></script>
+  </section>
+
+  <footer class="footer">
+    <p><strong>Categories:</strong> Coffee Shop</p>
+    <p><strong>Address:</strong> 100 S Beaver St, York, PA, United States, 17401</p>
+    <p><strong>Phone:</strong> (717) 848-4070</p>
+    <p><strong>Email:</strong> <a href="mailto:coffee.gbrc@gmail.com">coffee.gbrc@gmail.com</a></p>
+    <p><strong>Studied at:</strong> York College of Pennsylvania</p>
+  </footer>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/shop.html
+++ b/shop.html
@@ -33,6 +33,14 @@
       </div>
     </div>
   </section>
+
+  <footer class="footer">
+    <p><strong>Categories:</strong> Coffee Shop</p>
+    <p><strong>Address:</strong> 100 S Beaver St, York, PA, United States, 17401</p>
+    <p><strong>Phone:</strong> (717) 848-4070</p>
+    <p><strong>Email:</strong> <a href="mailto:coffee.gbrc@gmail.com">coffee.gbrc@gmail.com</a></p>
+    <p><strong>Studied at:</strong> York College of Pennsylvania</p>
+  </footer>
   <script src="script.js"></script>
 </body>
 </html>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -151,6 +151,20 @@ nav a {
   border-radius: 4px;
 }
 
+.footer {
+  background-color: #f6f0e7;
+  border-top: 2px solid #ddd;
+  text-align: center;
+  padding: 2em;
+  font-size: 0.9em;
+  color: #1b3c2b;
+}
+
+.footer a {
+  color: #1b3c2b;
+  text-decoration: none;
+}
+
 .send-button {
   background-color: #265e36;
   color: white;


### PR DESCRIPTION
## Summary
- add professional contact information footer to all pages
- highlight the founder's education
- style footer to match existing design

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c1b0147448326a3f1ff45c076d7d9