### PR TITLE
Fix hamburger menu overlay on mobile

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -13,6 +13,7 @@ body {
   background-color: #f6f0e7;
   border-bottom: 2px solid #ddd;
   position: relative;
+  z-index: 10;
 }
 
 .left-section {


### PR DESCRIPTION
## Summary
- ensure the top bar stays above the hero section so the hamburger menu can expand

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c263efac483268b6ba2cb16631a44