### PR TITLE
Improve menu aesthetics and specials loading

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -25,6 +25,10 @@
     </nav>
   </header>
 
+  <section class="menu-hero">
+    <h1>DISCOVER OUR MENU</h1>
+  </section>
+
   <section class="menu-section">
     <h2>OUR MENU</h2>
     <h3>Regular Offerings</h3>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -12,7 +12,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const specialsList = document.getElementById('specials-list');
 
   if (specialsTitle && specialsList) {
-    fetch('assets/specials.txt')
+    // Fetch the specials list from the assets folder. Using a relative
+    // path ensures this works regardless of where the site is hosted.
+    fetch('./assets/specials.txt')
       .then((response) => response.text())
       .then((text) => {
         const lines = text.trim().split('\n');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -61,6 +61,19 @@ nav a {
   max-width: 500px;
 }
 
+/* Hero section specifically for the menu page */
+.menu-hero {
+  background: url('../assets/Roast.PNG') no-repeat center center/cover;
+  color: white;
+  text-align: center;
+  padding: 6em 1em;
+}
+
+.menu-hero h1 {
+  font-size: 2.8em;
+  margin: 0;
+}
+
 .hero-text h1 {
   font-size: 3.2em;
   font-weight: bold;
@@ -164,7 +177,11 @@ nav a {
 }
 
 .menu-items li {
-  margin: 0.3em 0;
+  margin: 0.5em 0;
+  padding: 0.6em 1em;
+  background-color: #ffffff;
+  border: 1px solid #ccc;
+  border-radius: 6px;
 }
 
 .footer {
@@ -247,6 +264,14 @@ form button {
   }
 
   .hero-text h1 {
+    font-size: 2.2em;
+  }
+
+  .menu-hero {
+    padding: 4em 1em;
+  }
+
+  .menu-hero h1 {
     font-size: 2.2em;
   }
 


### PR DESCRIPTION
## Summary
- add a hero banner to menu page
- style menu list items with borders and padding
- fetch specials list using a relative path
- add menu hero styling and responsive tweaks

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c27819624832687401ad5233cf57a