### PR TITLE
Improve mobile navigation with overlay menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -24,6 +24,14 @@
       <a href="contact.html">CONTACT</a>
     </nav>
   </header>
+  <div id="mobile-menu" class="overlay-menu">
+    <div class="overlay-close">&times;</div>
+    <a href="index.html">HOME</a>
+    <a href="about.html">ABOUT</a>
+    <a href="shop.html">SHOP</a>
+    <a href="menu.html">MENU</a>
+    <a href="contact.html">CONTACT</a>
+  </div>
 
   <section class="hero">
     <div class="hero-text">

--- a/contact.html
+++ b/contact.html
@@ -24,6 +24,14 @@
       <a href="contact.html">CONTACT</a>
     </nav>
   </header>
+  <div id="mobile-menu" class="overlay-menu">
+    <div class="overlay-close">&times;</div>
+    <a href="index.html">HOME</a>
+    <a href="about.html">ABOUT</a>
+    <a href="shop.html">SHOP</a>
+    <a href="menu.html">MENU</a>
+    <a href="contact.html">CONTACT</a>
+  </div>
 
   <section class="products-contact">
     <div class="contact">

--- a/index.html
+++ b/index.html
@@ -24,6 +24,14 @@
       <a href="contact.html">CONTACT</a>
     </nav>
   </header>
+  <div id="mobile-menu" class="overlay-menu">
+    <div class="overlay-close">&times;</div>
+    <a href="index.html">HOME</a>
+    <a href="about.html">ABOUT</a>
+    <a href="shop.html">SHOP</a>
+    <a href="menu.html">MENU</a>
+    <a href="contact.html">CONTACT</a>
+  </div>
 
   <section class="hero">
     <div class="hero-text">

--- a/menu.html
+++ b/menu.html
@@ -24,6 +24,14 @@
       <a href="contact.html">CONTACT</a>
     </nav>
   </header>
+  <div id="mobile-menu" class="overlay-menu">
+    <div class="overlay-close">&times;</div>
+    <a href="index.html">HOME</a>
+    <a href="about.html">ABOUT</a>
+    <a href="shop.html">SHOP</a>
+    <a href="menu.html">MENU</a>
+    <a href="contact.html">CONTACT</a>
+  </div>
 
   <section class="menu-hero">
     <h1>DISCOVER OUR MENU</h1>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,10 +1,25 @@
 document.addEventListener('DOMContentLoaded', () => {
   const hamburger = document.querySelector('.hamburger');
-  const navMenu = document.querySelector('nav');
+  const mobileMenu = document.getElementById('mobile-menu');
+  const closeBtn = document.querySelector('.overlay-close');
 
-  if (hamburger && navMenu) {
+  if (hamburger && mobileMenu) {
     hamburger.addEventListener('click', () => {
-      navMenu.classList.toggle('show');
+      mobileMenu.classList.add('open');
+    });
+  }
+
+  if (closeBtn && mobileMenu) {
+    closeBtn.addEventListener('click', () => {
+      mobileMenu.classList.remove('open');
+    });
+  }
+
+  if (mobileMenu) {
+    mobileMenu.querySelectorAll('a').forEach((link) => {
+      link.addEventListener('click', () => {
+        mobileMenu.classList.remove('open');
+      });
     });
   }
 

--- a/shop.html
+++ b/shop.html
@@ -24,6 +24,14 @@
       <a href="contact.html">CONTACT</a>
     </nav>
   </header>
+  <div id="mobile-menu" class="overlay-menu">
+    <div class="overlay-close">&times;</div>
+    <a href="index.html">HOME</a>
+    <a href="about.html">ABOUT</a>
+    <a href="shop.html">SHOP</a>
+    <a href="menu.html">MENU</a>
+    <a href="contact.html">CONTACT</a>
+  </div>
 
   <section class="info-section">
     <div class="column">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -42,6 +42,10 @@ nav {
   display: flex;
 }
 
+.overlay-menu {
+  display: none;
+}
+
 nav a {
   margin-left: 1.5em;
   text-decoration: none;
@@ -284,5 +288,49 @@ form button {
     margin-left: auto;
     margin-right: auto;
     width: 60%;
+  }
+
+  .overlay-menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(246, 240, 231, 0.95);
+    backdrop-filter: blur(6px);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease;
+    z-index: 100;
+  }
+
+  .overlay-menu.open {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .overlay-menu a {
+    color: #1b3c2b;
+    font-size: 1.5em;
+    text-decoration: none;
+    margin: 0.6em 0;
+    transition: transform 0.2s, color 0.2s;
+  }
+
+  .overlay-menu a:hover {
+    color: #265e36;
+    transform: translateY(-3px);
+  }
+
+  .overlay-close {
+    position: absolute;
+    top: 1em;
+    right: 1em;
+    font-size: 2em;
+    cursor: pointer;
   }
 }


### PR DESCRIPTION
## Summary
- add full-screen overlay menu markup to all pages
- implement opening/closing logic in `main.js`
- style new overlay menu with blur effect and animations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c287249c48326a9c8216fa0e6f3c8