### PR TITLE
Add persistent cart icon

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
   <link rel="stylesheet" href="styles/styles.css" />
   <script defer src="scripts/main.js"></script>
+  <script defer src="scripts/shop.js"></script>
 </head>
 <body>
   <header class="top-bar">
@@ -23,6 +24,10 @@
       <a href="menu.html">MENU</a>
       <a href="contact.html">CONTACT</a>
     </nav>
+    <a href="#" class="cart-link" onclick="showCart()">
+      <span class="cart-icon">&#128722;</span>
+      <span class="cart-count">0</span>
+    </a>
   </header>
   <div id="mobile-menu" class="overlay-menu">
     <div class="overlay-close">&times;</div>
@@ -32,6 +37,10 @@
     <a href="shop.html">SHOP</a>
     <a href="menu.html">MENU</a>
     <a href="contact.html">CONTACT</a>
+    <a href="#" class="cart-link" onclick="showCart()">
+      <span class="cart-icon">&#128722;</span>
+      <span class="cart-count">0</span>
+    </a>
   </div>
 
   <section class="hero">
@@ -54,6 +63,13 @@
       and building long lasting relationships with our farmers and customers.</p>
     </div>
   </section>
+
+  <div id="cart-modal" class="cart-modal hidden">
+    <h2>Your Cart</h2>
+    <ul id="cart-items"></ul>
+    <p><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
+    <button onclick="closeCart()">Close</button>
+  </div>
 
   <footer class="footer">
     <p><strong>Address:</strong> <a href="https://www.google.com/maps/search/?api=1&query=100+S+Beaver+St,+York,+PA,+United+States,+17401">100 S Beaver St, York, PA, United States, 17401</a></p>

--- a/contact.html
+++ b/contact.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
   <link rel="stylesheet" href="styles/styles.css" />
   <script defer src="scripts/main.js"></script>
+  <script defer src="scripts/shop.js"></script>
 </head>
 <body>
   <header class="top-bar">
@@ -23,6 +24,10 @@
       <a href="menu.html">MENU</a>
       <a href="contact.html">CONTACT</a>
     </nav>
+    <a href="#" class="cart-link" onclick="showCart()">
+      <span class="cart-icon">&#128722;</span>
+      <span class="cart-count">0</span>
+    </a>
   </header>
   <div id="mobile-menu" class="overlay-menu">
     <div class="overlay-close">&times;</div>
@@ -32,6 +37,10 @@
     <a href="shop.html">SHOP</a>
     <a href="menu.html">MENU</a>
     <a href="contact.html">CONTACT</a>
+    <a href="#" class="cart-link" onclick="showCart()">
+      <span class="cart-icon">&#128722;</span>
+      <span class="cart-count">0</span>
+    </a>
   </div>
 
   <section class="products-contact">
@@ -49,6 +58,13 @@
       </form>
     </div>
   </section>
+
+  <div id="cart-modal" class="cart-modal hidden">
+    <h2>Your Cart</h2>
+    <ul id="cart-items"></ul>
+    <p><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
+    <button onclick="closeCart()">Close</button>
+  </div>
 
   <footer class="footer">
     <p><strong>Address:</strong> <a href="https://www.google.com/maps/search/?api=1&query=100+S+Beaver+St,+York,+PA,+United+States,+17401">100 S Beaver St, York, PA, United States, 17401</a></p>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
   <link rel="stylesheet" href="styles/styles.css" />
   <script defer src="scripts/main.js"></script>
+  <script defer src="scripts/shop.js"></script>
 </head>
 <body>
   <header class="top-bar">
@@ -23,6 +24,10 @@
       <a href="menu.html">MENU</a>
       <a href="contact.html">CONTACT</a>
     </nav>
+    <a href="#" class="cart-link" onclick="showCart()">
+      <span class="cart-icon">&#128722;</span>
+      <span class="cart-count">0</span>
+    </a>
   </header>
   <div id="mobile-menu" class="overlay-menu">
     <div class="overlay-close">&times;</div>
@@ -32,6 +37,10 @@
     <a href="shop.html">SHOP</a>
     <a href="menu.html">MENU</a>
     <a href="contact.html">CONTACT</a>
+    <a href="#" class="cart-link" onclick="showCart()">
+      <span class="cart-icon">&#128722;</span>
+      <span class="cart-count">0</span>
+    </a>
   </div>
 
   <section class="hero">
@@ -79,6 +88,13 @@
       </form>
     </div>
   </section>
+
+  <div id="cart-modal" class="cart-modal hidden">
+    <h2>Your Cart</h2>
+    <ul id="cart-items"></ul>
+    <p><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
+    <button onclick="closeCart()">Close</button>
+  </div>
 
   <footer class="footer">
     <p><strong>Address:</strong> <a href="https://www.google.com/maps/search/?api=1&query=100+S+Beaver+St,+York,+PA,+United+States,+17401">100 S Beaver St, York, PA, United States, 17401</a></p>

--- a/menu.html
+++ b/menu.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
   <link rel="stylesheet" href="styles/styles.css" />
   <script defer src="scripts/main.js"></script>
+  <script defer src="scripts/shop.js"></script>
 </head>
 <body>
   <header class="top-bar">
@@ -23,6 +24,10 @@
       <a href="menu.html">MENU</a>
       <a href="contact.html">CONTACT</a>
     </nav>
+    <a href="#" class="cart-link" onclick="showCart()">
+      <span class="cart-icon">&#128722;</span>
+      <span class="cart-count">0</span>
+    </a>
   </header>
   <div id="mobile-menu" class="overlay-menu">
     <div class="overlay-close">&times;</div>
@@ -32,6 +37,10 @@
     <a href="shop.html">SHOP</a>
     <a href="menu.html">MENU</a>
     <a href="contact.html">CONTACT</a>
+    <a href="#" class="cart-link" onclick="showCart()">
+      <span class="cart-icon">&#128722;</span>
+      <span class="cart-count">0</span>
+    </a>
   </div>
 
   <section class="menu-header">
@@ -63,6 +72,13 @@
       <ul id="specials-list"></ul>
     </section>
   </main>
+
+  <div id="cart-modal" class="cart-modal hidden">
+    <h2>Your Cart</h2>
+    <ul id="cart-items"></ul>
+    <p><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
+    <button onclick="closeCart()">Close</button>
+  </div>
 
   <footer class="footer">
     <p><strong>Address:</strong> <a href="https://www.google.com/maps/search/?api=1&query=100+S+Beaver+St,+York,+PA,+United+States,+17401">100 S Beaver St, York, PA, United States, 17401</a></p>

--- a/scripts/shop.js
+++ b/scripts/shop.js
@@ -11,10 +11,9 @@ function addToCart(name, price, id) {
 }
 
 function updateCartCount() {
-  const countEl = document.getElementById('cart-count');
-  if (countEl) {
-    countEl.textContent = cart.length;
-  }
+  document.querySelectorAll('.cart-count').forEach((el) => {
+    el.textContent = cart.length;
+  });
 }
 
 function showCart() {

--- a/shop.html
+++ b/shop.html
@@ -23,8 +23,11 @@
       <a href="shop.html">SHOP</a>
       <a href="menu.html">MENU</a>
       <a href="contact.html">CONTACT</a>
-      <a href="#" onclick="showCart()">Cart (<span id="cart-count">0</span>)</a>
     </nav>
+    <a href="#" class="cart-link" onclick="showCart()">
+      <span class="cart-icon">&#128722;</span>
+      <span class="cart-count">0</span>
+    </a>
   </header>
   <div id="mobile-menu" class="overlay-menu">
     <div class="overlay-close">&times;</div>
@@ -34,6 +37,10 @@
     <a href="shop.html">SHOP</a>
     <a href="menu.html">MENU</a>
     <a href="contact.html">CONTACT</a>
+    <a href="#" class="cart-link" onclick="showCart()">
+      <span class="cart-icon">&#128722;</span>
+      <span class="cart-count">0</span>
+    </a>
   </div>
 
   <main class="shop-main">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -485,3 +485,22 @@ form button {
 .hidden {
   display: none;
 }
+
+.cart-link {
+  margin-left: 1.5em;
+  text-decoration: none;
+  color: #1b3c2b;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+}
+
+.cart-icon {
+  font-size: 1.2em;
+}
+
+@media (max-width: 768px) {
+  .cart-link {
+    margin-left: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- include shop.js on all pages
- add cart icon with item count to every header and mobile menu
- style cart link for mobile
- keep cart state across pages via shared script

## Testing
- `npx --yes htmlhint **/*.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684c3589b13c8326b49429d9c58688de