### PR TITLE
Refine navigation and cart modal

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,17 +17,23 @@
         <img src="assets/TheGreenBeanLogoHorizontal.png" alt="Green Bean Logo">
       </div>
     </div>
-    <nav>
-      <a href="index.html">HOME</a>
-      <a href="about.html">ABOUT</a>
-      <a href="shop.html">SHOP</a>
-      <a href="menu.html">MENU</a>
-      <a href="contact.html">CONTACT</a>
-    </nav>
-    <a href="#" class="cart-link" onclick="showCart()">
-      <span class="cart-icon">&#128722;</span>
-      <span class="cart-count">0</span>
-    </a>
+    <div class="right-section">
+      <nav>
+        <a href="index.html">HOME</a>
+        <a href="about.html">ABOUT</a>
+        <a href="shop.html">SHOP</a>
+        <a href="menu.html">MENU</a>
+        <a href="contact.html">CONTACT</a>
+      </nav>
+      <a href="#" class="cart-link" onclick="showCart()">
+        <svg class="cart-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M3 3h2l.6 3h15l-1.2 6H7.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="9" cy="19" r="2"/>
+          <circle cx="17" cy="19" r="2"/>
+        </svg>
+        <span class="cart-count">0</span>
+      </a>
+    </div>
   </header>
   <div id="mobile-menu" class="overlay-menu">
     <div class="overlay-close">&times;</div>
@@ -38,7 +44,11 @@
     <a href="menu.html">MENU</a>
     <a href="contact.html">CONTACT</a>
     <a href="#" class="cart-link" onclick="showCart()">
-      <span class="cart-icon">&#128722;</span>
+      <svg class="cart-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M3 3h2l.6 3h15l-1.2 6H7.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="9" cy="19" r="2"/>
+        <circle cx="17" cy="19" r="2"/>
+      </svg>
       <span class="cart-count">0</span>
     </a>
   </div>
@@ -64,11 +74,11 @@
     </div>
   </section>
 
-  <div id="cart-modal" class="cart-modal hidden">
+  <div id="cart-modal" class="cart-modal">
+    <button class="cart-close" onclick="closeCart()">&times;</button>
     <h2>Your Cart</h2>
     <ul id="cart-items"></ul>
-    <p><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
-    <button onclick="closeCart()">Close</button>
+    <p class="cart-total"><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
   </div>
 
   <footer class="footer">

--- a/contact.html
+++ b/contact.html
@@ -17,17 +17,23 @@
         <img src="assets/TheGreenBeanLogoHorizontal.png" alt="Green Bean Logo">
       </div>
     </div>
-    <nav>
-      <a href="index.html">HOME</a>
-      <a href="about.html">ABOUT</a>
-      <a href="shop.html">SHOP</a>
-      <a href="menu.html">MENU</a>
-      <a href="contact.html">CONTACT</a>
-    </nav>
-    <a href="#" class="cart-link" onclick="showCart()">
-      <span class="cart-icon">&#128722;</span>
-      <span class="cart-count">0</span>
-    </a>
+    <div class="right-section">
+      <nav>
+        <a href="index.html">HOME</a>
+        <a href="about.html">ABOUT</a>
+        <a href="shop.html">SHOP</a>
+        <a href="menu.html">MENU</a>
+        <a href="contact.html">CONTACT</a>
+      </nav>
+      <a href="#" class="cart-link" onclick="showCart()">
+        <svg class="cart-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M3 3h2l.6 3h15l-1.2 6H7.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="9" cy="19" r="2"/>
+          <circle cx="17" cy="19" r="2"/>
+        </svg>
+        <span class="cart-count">0</span>
+      </a>
+    </div>
   </header>
   <div id="mobile-menu" class="overlay-menu">
     <div class="overlay-close">&times;</div>
@@ -38,7 +44,11 @@
     <a href="menu.html">MENU</a>
     <a href="contact.html">CONTACT</a>
     <a href="#" class="cart-link" onclick="showCart()">
-      <span class="cart-icon">&#128722;</span>
+      <svg class="cart-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M3 3h2l.6 3h15l-1.2 6H7.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="9" cy="19" r="2"/>
+        <circle cx="17" cy="19" r="2"/>
+      </svg>
       <span class="cart-count">0</span>
     </a>
   </div>
@@ -59,11 +69,11 @@
     </div>
   </section>
 
-  <div id="cart-modal" class="cart-modal hidden">
+  <div id="cart-modal" class="cart-modal">
+    <button class="cart-close" onclick="closeCart()">&times;</button>
     <h2>Your Cart</h2>
     <ul id="cart-items"></ul>
-    <p><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
-    <button onclick="closeCart()">Close</button>
+    <p class="cart-total"><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
   </div>
 
   <footer class="footer">

--- a/index.html
+++ b/index.html
@@ -17,17 +17,23 @@
         <img src="assets/TheGreenBeanLogoHorizontal.png" alt="Green Bean Logo">
       </div>
     </div>
-    <nav>
-      <a href="index.html">HOME</a>
-      <a href="about.html">ABOUT</a>
-      <a href="shop.html">SHOP</a>
-      <a href="menu.html">MENU</a>
-      <a href="contact.html">CONTACT</a>
-    </nav>
-    <a href="#" class="cart-link" onclick="showCart()">
-      <span class="cart-icon">&#128722;</span>
-      <span class="cart-count">0</span>
-    </a>
+    <div class="right-section">
+      <nav>
+        <a href="index.html">HOME</a>
+        <a href="about.html">ABOUT</a>
+        <a href="shop.html">SHOP</a>
+        <a href="menu.html">MENU</a>
+        <a href="contact.html">CONTACT</a>
+      </nav>
+      <a href="#" class="cart-link" onclick="showCart()">
+        <svg class="cart-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M3 3h2l.6 3h15l-1.2 6H7.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="9" cy="19" r="2"/>
+          <circle cx="17" cy="19" r="2"/>
+        </svg>
+        <span class="cart-count">0</span>
+      </a>
+    </div>
   </header>
   <div id="mobile-menu" class="overlay-menu">
     <div class="overlay-close">&times;</div>
@@ -38,7 +44,11 @@
     <a href="menu.html">MENU</a>
     <a href="contact.html">CONTACT</a>
     <a href="#" class="cart-link" onclick="showCart()">
-      <span class="cart-icon">&#128722;</span>
+      <svg class="cart-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M3 3h2l.6 3h15l-1.2 6H7.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="9" cy="19" r="2"/>
+        <circle cx="17" cy="19" r="2"/>
+      </svg>
       <span class="cart-count">0</span>
     </a>
   </div>
@@ -89,11 +99,11 @@
     </div>
   </section>
 
-  <div id="cart-modal" class="cart-modal hidden">
+  <div id="cart-modal" class="cart-modal">
+    <button class="cart-close" onclick="closeCart()">&times;</button>
     <h2>Your Cart</h2>
     <ul id="cart-items"></ul>
-    <p><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
-    <button onclick="closeCart()">Close</button>
+    <p class="cart-total"><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
   </div>
 
   <footer class="footer">

--- a/menu.html
+++ b/menu.html
@@ -17,17 +17,23 @@
         <img src="assets/TheGreenBeanLogoHorizontal.png" alt="Green Bean Logo">
       </div>
     </div>
-    <nav>
-      <a href="index.html">HOME</a>
-      <a href="about.html">ABOUT</a>
-      <a href="shop.html">SHOP</a>
-      <a href="menu.html">MENU</a>
-      <a href="contact.html">CONTACT</a>
-    </nav>
-    <a href="#" class="cart-link" onclick="showCart()">
-      <span class="cart-icon">&#128722;</span>
-      <span class="cart-count">0</span>
-    </a>
+    <div class="right-section">
+      <nav>
+        <a href="index.html">HOME</a>
+        <a href="about.html">ABOUT</a>
+        <a href="shop.html">SHOP</a>
+        <a href="menu.html">MENU</a>
+        <a href="contact.html">CONTACT</a>
+      </nav>
+      <a href="#" class="cart-link" onclick="showCart()">
+        <svg class="cart-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M3 3h2l.6 3h15l-1.2 6H7.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="9" cy="19" r="2"/>
+          <circle cx="17" cy="19" r="2"/>
+        </svg>
+        <span class="cart-count">0</span>
+      </a>
+    </div>
   </header>
   <div id="mobile-menu" class="overlay-menu">
     <div class="overlay-close">&times;</div>
@@ -38,7 +44,11 @@
     <a href="menu.html">MENU</a>
     <a href="contact.html">CONTACT</a>
     <a href="#" class="cart-link" onclick="showCart()">
-      <span class="cart-icon">&#128722;</span>
+      <svg class="cart-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M3 3h2l.6 3h15l-1.2 6H7.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="9" cy="19" r="2"/>
+        <circle cx="17" cy="19" r="2"/>
+      </svg>
       <span class="cart-count">0</span>
     </a>
   </div>
@@ -73,11 +83,11 @@
     </section>
   </main>
 
-  <div id="cart-modal" class="cart-modal hidden">
+  <div id="cart-modal" class="cart-modal">
+    <button class="cart-close" onclick="closeCart()">&times;</button>
     <h2>Your Cart</h2>
     <ul id="cart-items"></ul>
-    <p><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
-    <button onclick="closeCart()">Close</button>
+    <p class="cart-total"><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
   </div>
 
   <footer class="footer">

--- a/scripts/shop.js
+++ b/scripts/shop.js
@@ -35,11 +35,11 @@ function showCart() {
   });
 
   total.textContent = sum.toFixed(2);
-  modal.classList.remove('hidden');
+  modal.classList.add('open');
 }
 
 function closeCart() {
-  document.getElementById('cart-modal').classList.add('hidden');
+  document.getElementById('cart-modal').classList.remove('open');
 }
 
 updateCartCount();

--- a/shop.html
+++ b/shop.html
@@ -17,17 +17,23 @@
         <img src="assets/TheGreenBeanLogoHorizontal.png" alt="Green Bean Logo">
       </div>
     </div>
-    <nav>
-      <a href="index.html">HOME</a>
-      <a href="about.html">ABOUT</a>
-      <a href="shop.html">SHOP</a>
-      <a href="menu.html">MENU</a>
-      <a href="contact.html">CONTACT</a>
-    </nav>
-    <a href="#" class="cart-link" onclick="showCart()">
-      <span class="cart-icon">&#128722;</span>
-      <span class="cart-count">0</span>
-    </a>
+    <div class="right-section">
+      <nav>
+        <a href="index.html">HOME</a>
+        <a href="about.html">ABOUT</a>
+        <a href="shop.html">SHOP</a>
+        <a href="menu.html">MENU</a>
+        <a href="contact.html">CONTACT</a>
+      </nav>
+      <a href="#" class="cart-link" onclick="showCart()">
+        <svg class="cart-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M3 3h2l.6 3h15l-1.2 6H7.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="9" cy="19" r="2"/>
+          <circle cx="17" cy="19" r="2"/>
+        </svg>
+        <span class="cart-count">0</span>
+      </a>
+    </div>
   </header>
   <div id="mobile-menu" class="overlay-menu">
     <div class="overlay-close">&times;</div>
@@ -38,7 +44,11 @@
     <a href="menu.html">MENU</a>
     <a href="contact.html">CONTACT</a>
     <a href="#" class="cart-link" onclick="showCart()">
-      <span class="cart-icon">&#128722;</span>
+      <svg class="cart-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M3 3h2l.6 3h15l-1.2 6H7.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="9" cy="19" r="2"/>
+        <circle cx="17" cy="19" r="2"/>
+      </svg>
       <span class="cart-count">0</span>
     </a>
   </div>
@@ -151,11 +161,11 @@
     </div>
   </main>
 
-  <div id="cart-modal" class="cart-modal hidden">
+  <div id="cart-modal" class="cart-modal">
+    <button class="cart-close" onclick="closeCart()">&times;</button>
     <h2>Your Cart</h2>
     <ul id="cart-items"></ul>
-    <p><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
-    <button onclick="closeCart()">Close</button>
+    <p class="cart-total"><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
   </div>
 
   <footer class="footer">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -42,6 +42,11 @@ nav {
   display: flex;
 }
 
+.right-section {
+  display: flex;
+  align-items: center;
+}
+
 .overlay-menu {
   display: none;
 }
@@ -472,22 +477,54 @@ form button {
 
 .cart-modal {
   position: fixed;
-  top: 10%;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
-  background: white;
+  transform: translate(-50%, -50%) scale(0.95);
+  background: #fff;
   border: 1px solid #ccc;
-  padding: 2rem;
-  z-index: 10;
+  padding: 1.5rem;
+  z-index: 200;
   border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
-.hidden {
-  display: none;
+.cart-modal.open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.cart-modal ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1em;
+}
+
+.cart-modal li {
+  border-bottom: 1px solid #eee;
+  padding: 0.5em 0;
+}
+
+.cart-close {
+  position: absolute;
+  top: 0.3em;
+  right: 0.5em;
+  background: none;
+  border: none;
+  font-size: 1.4em;
+  cursor: pointer;
+  line-height: 1;
 }
 
 .cart-link {
-  margin-left: 1.5em;
+  margin-left: 1em;
   text-decoration: none;
   color: #1b3c2b;
   font-weight: 600;
@@ -496,7 +533,10 @@ form button {
 }
 
 .cart-icon {
-  font-size: 1.2em;
+  width: 1.3em;
+  height: 1.3em;
+  fill: currentColor;
+  margin-right: 0.2em;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- place navigation links beside the cart icon
- swap emoji cart for inline SVG icon
- redesign cart modal with animation and close button
- adapt styles for new layout and modal
- update shop script for open/close animation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c37ef8ad08326874608f5e02ec560