### PR TITLE
Improve Safari mobile styles and update contact links

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -56,7 +56,19 @@
   <section class="products-contact">
     <div class="contact">
       <h2>CONTACT US</h2>
-      <p class="contact-phone"><a href="tel:7178484070">(717) 848-4070</a></p>
+      <div class="contact-links">
+        <a class="contact-icon" href="tel:7178484070" aria-label="Call us">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.86 19.86 0 0 1-8.63-3.13 19.5 19.5 0 0 1-6-6A19.86 19.86 0 0 1 2.08 4.18 2 2 0 0 1 4.06 2h3a2 2 0 0 1 2 1.72c.12.81.37 1.6.72 2.34a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.74-1.74a2 2 0 0 1 2.11-.45c.74.35 1.53.6 2.34.72A2 2 0 0 1 22 16.92z"/>
+          </svg>
+        </a>
+        <a class="contact-icon" href="mailto:coffee.gbrc@gmail.com" aria-label="Email us">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/>
+            <polyline points="22,6 12,13 2,6" />
+          </svg>
+        </a>
+      </div>
       <div class="map-container">
         <iframe src="https://www.google.com/maps?q=100+S+Beaver+St,+York,+PA+17401&output=embed" loading="lazy"></iframe>
       </div>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -160,8 +160,34 @@ nav a {
   margin: 0 auto;
 }
 
-.contact-phone {
+
+/* Contact icons container */
+.contact-links {
+  display: flex;
+  gap: 1em;
   margin-bottom: 1em;
+}
+
+.contact-links .contact-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background-color: #265e36;
+  color: #fff;
+  border-radius: 50%;
+  text-decoration: none;
+  transition: background-color 0.2s;
+}
+
+.contact-links .contact-icon:hover {
+  background-color: #1b3c2b;
+}
+
+.contact-links svg {
+  width: 20px;
+  height: 20px;
 }
 
 .map-container iframe {
@@ -351,6 +377,7 @@ form button {
     right: 0;
     bottom: 0;
     background: rgba(246, 240, 231, 0.95);
+    -webkit-backdrop-filter: blur(6px);
     backdrop-filter: blur(6px);
     display: flex;
     flex-direction: column;
@@ -451,12 +478,19 @@ form button {
 
 .product select {
   margin-top: 0.2rem;
-  padding: 0.4em;
+  padding: 0.4em 2em 0.4em 0.4em;
   border: 1px solid #ccc;
   border-radius: 4px;
   font-size: 0.9em;
   cursor: pointer;
   background-color: #fdfdfd;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath fill='none' stroke='%231b3c2b' stroke-width='2' d='M1 1l4 4 4-4'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.6em center;
+  background-size: 10px 6px;
 }
 
 .product button {


### PR DESCRIPTION
## Summary
- ensure overlay uses `-webkit-backdrop-filter` for Safari
- restyle select drop-downs with custom arrow for wider browser support
- add vector buttons for phone and email on the contact page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c3d2b118c8326b03f93b33bbf478e