### PR TITLE
Add PayPal checkout integration

### DIFF
--- a/about.html
+++ b/about.html
@@ -79,6 +79,14 @@
     <h2>Your Cart</h2>
     <ul id="cart-items"></ul>
     <p class="cart-total"><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
+    <form id="paypal-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+      <input type="hidden" name="cmd" value="_xclick">
+      <input type="hidden" name="business" value="your-paypal-email@example.com">
+      <input type="hidden" name="item_name" value="Green Bean Cart Purchase">
+      <input type="hidden" name="amount" value="0.00">
+      <input type="hidden" name="currency_code" value="USD">
+      <input type="submit" value="Checkout with PayPal" class="paypal-button">
+    </form>
   </div>
 
   <footer class="footer">

--- a/contact.html
+++ b/contact.html
@@ -86,6 +86,14 @@
     <h2>Your Cart</h2>
     <ul id="cart-items"></ul>
     <p class="cart-total"><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
+    <form id="paypal-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+      <input type="hidden" name="cmd" value="_xclick">
+      <input type="hidden" name="business" value="your-paypal-email@example.com">
+      <input type="hidden" name="item_name" value="Green Bean Cart Purchase">
+      <input type="hidden" name="amount" value="0.00">
+      <input type="hidden" name="currency_code" value="USD">
+      <input type="submit" value="Checkout with PayPal" class="paypal-button">
+    </form>
   </div>
 
   <footer class="footer">

--- a/index.html
+++ b/index.html
@@ -104,6 +104,14 @@
     <h2>Your Cart</h2>
     <ul id="cart-items"></ul>
     <p class="cart-total"><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
+    <form id="paypal-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+      <input type="hidden" name="cmd" value="_xclick">
+      <input type="hidden" name="business" value="your-paypal-email@example.com">
+      <input type="hidden" name="item_name" value="Green Bean Cart Purchase">
+      <input type="hidden" name="amount" value="0.00">
+      <input type="hidden" name="currency_code" value="USD">
+      <input type="submit" value="Checkout with PayPal" class="paypal-button">
+    </form>
   </div>
 
   <footer class="footer">

--- a/menu.html
+++ b/menu.html
@@ -88,6 +88,14 @@
     <h2>Your Cart</h2>
     <ul id="cart-items"></ul>
     <p class="cart-total"><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
+    <form id="paypal-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+      <input type="hidden" name="cmd" value="_xclick">
+      <input type="hidden" name="business" value="your-paypal-email@example.com">
+      <input type="hidden" name="item_name" value="Green Bean Cart Purchase">
+      <input type="hidden" name="amount" value="0.00">
+      <input type="hidden" name="currency_code" value="USD">
+      <input type="submit" value="Checkout with PayPal" class="paypal-button">
+    </form>
   </div>
 
   <footer class="footer">

--- a/scripts/shop.js
+++ b/scripts/shop.js
@@ -20,6 +20,7 @@ function showCart() {
   const modal = document.getElementById('cart-modal');
   const list = document.getElementById('cart-items');
   const total = document.getElementById('cart-total');
+  const paypalAmount = document.querySelector('#paypal-form input[name="amount"]');
 
   list.innerHTML = '';
   let sum = 0;
@@ -35,6 +36,9 @@ function showCart() {
   });
 
   total.textContent = sum.toFixed(2);
+  if (paypalAmount) {
+    paypalAmount.value = sum.toFixed(2);
+  }
   modal.classList.add('open');
 }
 

--- a/shop.html
+++ b/shop.html
@@ -166,6 +166,14 @@
     <h2>Your Cart</h2>
     <ul id="cart-items"></ul>
     <p class="cart-total"><strong>Total:</strong> $<span id="cart-total">0.00</span></p>
+    <form id="paypal-form" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+      <input type="hidden" name="cmd" value="_xclick">
+      <input type="hidden" name="business" value="your-paypal-email@example.com">
+      <input type="hidden" name="item_name" value="Green Bean Cart Purchase">
+      <input type="hidden" name="amount" value="0.00">
+      <input type="hidden" name="currency_code" value="USD">
+      <input type="submit" value="Checkout with PayPal" class="paypal-button">
+    </form>
   </div>
 
   <footer class="footer">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -578,3 +578,19 @@ form button {
     margin-left: 0;
   }
 }
+
+.paypal-button {
+  background-color: #0070ba;
+  color: #fff;
+  border: none;
+  padding: 0.6em 1.2em;
+  border-radius: 6px;
+  font-size: 1em;
+  cursor: pointer;
+  width: 100%;
+  margin-top: 1em;
+}
+
+#paypal-form {
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- embed PayPal checkout form inside cart modal across all pages
- style PayPal button and form for mobile friendliness
- update cart script to set PayPal total dynamically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c3e75860883269b776ba29edf7127