### PR TITLE
Improve trash icon and menu layout

### DIFF
--- a/scripts/shop.js
+++ b/scripts/shop.js
@@ -36,7 +36,7 @@ function showCart() {
     const btn = document.createElement('button');
     btn.className = 'remove-btn';
     btn.innerHTML =
-      '<svg class="trash-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M9 6v12m6-12v12M4 6l1-3h14l1 3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+      '<svg class="trash-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3m-7 4v6m4-6v6M5 7h14l-1 12H6L5 7z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
     btn.addEventListener('click', () => removeFromCart(idx));
     li.appendChild(span);
     li.appendChild(btn);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -136,6 +136,7 @@ nav a {
 
 .roaster-info {
   flex: 1;
+  text-align: right;
 }
 
 .column h2 {
@@ -162,7 +163,7 @@ nav a {
 }
 
 .roaster-container .roaster-img {
-  margin-left: auto;
+  margin-left: 0;
 }
 
 


### PR DESCRIPTION
## Summary
- tweak the remove button icon to a more recognizable trashcan
- right-align menu header/button and reduce spacing to the roaster image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c498322b48326bc1737819cccab8a