### PR TITLE
Fix roaster image centering on mobile

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -416,6 +416,12 @@ form button {
     width: 60%;
   }
 
+  /* Center the roaster image within its container on small screens */
+  .roaster-container .roaster-img {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
   .overlay-menu {
     position: fixed;
     top: 0;


### PR DESCRIPTION
## Summary
- ensure `.roaster-img` is centered in its container on mobile screens

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c58331d2c8326b237e4ee30172e72