### PR TITLE
Center menu section on mobile

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -397,6 +397,11 @@ form button {
     align-items: center;
   }
 
+  /* Center menu heading and button on mobile */
+  .roaster-info {
+    text-align: center;
+  }
+
   .menu-hero {
     padding: 4em 1em;
   }


### PR DESCRIPTION
## Summary
- tweak mobile styles so the menu section heading and button are centered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c596053f08326952c16bd046d6b19