### PR TITLE
Update menu prices and improve trashcan icon

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -55,29 +55,30 @@
 
   <section class="menu-header">
     <h1>MENU</h1>
-    <div class="menu-size-header">
-      <span class="item-label">Drink</span>
-      <span>Small</span>
-      <span>Medium</span>
-      <span>Large</span>
-    </div>
   </section>
 
   <main class="menu-content">
     <section class="menu-section">
-      <h2>BEVERAGES</h2>
+      <div class="menu-section-header">
+        <h2>BEVERAGES</h2>
+        <div class="size-labels">
+          <span>Small</span>
+          <span>Medium</span>
+          <span>Large</span>
+        </div>
+      </div>
       <ul>
-        <li><span>Coffee</span><span></span><span></span><span></span></li>
-        <li><span>Latte</span><span></span><span></span><span></span></li>
-        <li><span>Mocha/White Mocha</span><span></span><span></span><span></span></li>
-        <li><span>Americano</span><span></span><span></span><span></span></li>
-        <li><span>Cafe Au Lait</span><span></span><span></span><span></span></li>
-        <li><span>Hot Chocolate</span><span></span><span></span><span></span></li>
-        <li><span>Hot Tea</span><span></span><span></span><span></span></li>
-        <li><span>Espresso</span><span></span><span></span><span></span></li>
-        <li><span>Mocha Frappe</span><span></span><span></span><span></span></li>
-        <li><span>Vanilla Frappe</span><span></span><span></span><span></span></li>
-        <li><span>Chocolate Peanut Butter Frappe</span><span></span><span></span><span></span></li>
+        <li><span>Coffee</span><span>$1.50</span><span>$2.25</span><span>$2.75</span></li>
+        <li><span>Latte</span><span>$3.00</span><span>$3.75</span><span>$4.25</span></li>
+        <li><span>Mocha/White Mocha</span><span>$3.25</span><span>$4.00</span><span>$4.50</span></li>
+        <li><span>Americano</span><span>$2.00</span><span>$2.50</span><span>$3.00</span></li>
+        <li><span>Cafe Au Lait</span><span>$2.75</span><span>$3.25</span><span>$3.75</span></li>
+        <li><span>Hot Chocolate</span><span>$2.25</span><span>$2.75</span><span>$3.25</span></li>
+        <li><span>Hot Tea</span><span>$1.75</span><span>$2.25</span><span>$2.75</span></li>
+        <li><span>Espresso</span><span>$2.00</span><span>$3.00</span><span>$4.00</span></li>
+        <li><span>Mocha Frappe</span><span>$4.25</span><span>$4.75</span><span>$5.25</span></li>
+        <li><span>Vanilla Frappe</span><span>$4.00</span><span>$4.50</span><span>$5.00</span></li>
+        <li><span>Chocolate Peanut Butter Frappe</span><span>$4.50</span><span>$5.00</span><span>$5.50</span></li>
       </ul>
     </section>
   </main>

--- a/scripts/shop.js
+++ b/scripts/shop.js
@@ -49,7 +49,7 @@ function showCart() {
     const btn = document.createElement("button");
     btn.className = "remove-btn";
     btn.innerHTML =
-      '<svg class="trash-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18v14a2 2 0 01-2 2H5a2 2 0 01-2-2V6zm5-3h8v3H8V3z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+      '<svg class="trash-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22m-5 0V5a2 2 0 00-2-2H8a2 2 0 00-2 2v2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
     btn.addEventListener("click", () => removeFromCart(idx));
     li.appendChild(wrap);
     li.appendChild(btn);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -273,9 +273,7 @@ nav a {
 .menu-section h2 {
   font-size: 1.5rem;
   color: #0f3d2e;
-  border-bottom: 2px solid #e6dac2;
-  padding-bottom: 10px;
-  margin-bottom: 20px;
+  margin: 0;
 }
 
 .menu-section ul {
@@ -293,14 +291,27 @@ nav a {
   font-weight: 500;
 }
 
-.menu-size-header {
+
+.menu-section-header {
   display: flex;
   justify-content: space-between;
-  padding: 12px 0;
+  align-items: flex-end;
   border-bottom: 2px solid #e6dac2;
+  padding-bottom: 10px;
+  margin-bottom: 20px;
+}
+
+.menu-section-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #0f3d2e;
+}
+
+.size-labels {
+  display: flex;
+  gap: 1.5em;
   font-size: 1.1rem;
   font-weight: 600;
-  margin-bottom: 10px;
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- redesign menu layout to place size labels beside the BEVERAGES heading
- restore beverage prices for small/medium/large sizes
- style new menu header layout
- update trash icon SVG to look more like a trashcan

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c633a088c8326a646167a7e11f929