### PR TITLE
Add operating hours to contact page and footer

### DIFF
--- a/about.html
+++ b/about.html
@@ -94,7 +94,7 @@
     <p><strong>Address:</strong> <a href="https://www.google.com/maps/search/?api=1&query=100+S+Beaver+St,+York,+PA,+United+States,+17401">100 S Beaver St, York, PA, United States, 17401</a></p>
     <p><strong>Phone:</strong> <a href="tel:7178484070">(717) 848-4070</a></p>
     <p><strong>Email:</strong> <a href="mailto:coffee.gbrc@gmail.com">coffee.gbrc@gmail.com</a></p>
-    <p><strong>Studied at:</strong> York College of Pennsylvania</p>
+    <p class="hours"><strong>Hours:</strong> Monday - Friday 7am - 4pm<br>Closed Saturday &amp; Sunday</p>
   </footer>
   </body>
   </html>

--- a/contact.html
+++ b/contact.html
@@ -84,6 +84,7 @@
       <div class="map-container">
         <iframe src="https://www.google.com/maps?q=100+S+Beaver+St,+York,+PA+17401&output=embed" loading="lazy"></iframe>
       </div>
+      <p class="hours"><strong>Hours:</strong> Monday - Friday 7am - 4pm<br>Closed Saturday &amp; Sunday</p>
       <form>
         <input type="text" placeholder="Name" required/>
         <input type="email" placeholder="Email" required/>
@@ -112,7 +113,7 @@
     <p><strong>Address:</strong> <a href="https://www.google.com/maps/search/?api=1&query=100+S+Beaver+St,+York,+PA,+United+States,+17401">100 S Beaver St, York, PA, United States, 17401</a></p>
     <p><strong>Phone:</strong> <a href="tel:7178484070">(717) 848-4070</a></p>
     <p><strong>Email:</strong> <a href="mailto:coffee.gbrc@gmail.com">coffee.gbrc@gmail.com</a></p>
-    <p><strong>Studied at:</strong> York College of Pennsylvania</p>
+    <p class="hours"><strong>Hours:</strong> Monday - Friday 7am - 4pm<br>Closed Saturday &amp; Sunday</p>
   </footer>
   
   </body>

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
     <p><strong>Address:</strong> <a href="https://www.google.com/maps/search/?api=1&query=100+S+Beaver+St,+York,+PA,+United+States,+17401">100 S Beaver St, York, PA, United States, 17401</a></p>
     <p><strong>Phone:</strong> <a href="tel:7178484070">(717) 848-4070</a></p>
     <p><strong>Email:</strong> <a href="mailto:coffee.gbrc@gmail.com">coffee.gbrc@gmail.com</a></p>
-    <p><strong>Studied at:</strong> York College of Pennsylvania</p>
+    <p class="hours"><strong>Hours:</strong> Monday - Friday 7am - 4pm<br>Closed Saturday &amp; Sunday</p>
   </footer>
 </body>
 </html>

--- a/menu.html
+++ b/menu.html
@@ -102,7 +102,7 @@
     <p><strong>Address:</strong> <a href="https://www.google.com/maps/search/?api=1&query=100+S+Beaver+St,+York,+PA,+United+States,+17401">100 S Beaver St, York, PA, United States, 17401</a></p>
     <p><strong>Phone:</strong> <a href="tel:7178484070">(717) 848-4070</a></p>
     <p><strong>Email:</strong> <a href="mailto:coffee.gbrc@gmail.com">coffee.gbrc@gmail.com</a></p>
-    <p><strong>Studied at:</strong> York College of Pennsylvania</p>
+    <p class="hours"><strong>Hours:</strong> Monday - Friday 7am - 4pm<br>Closed Saturday &amp; Sunday</p>
   </footer>
   
 </body>

--- a/shop.html
+++ b/shop.html
@@ -253,7 +253,7 @@
         <strong>Email:</strong>
         <a href="mailto:coffee.gbrc@gmail.com">coffee.gbrc@gmail.com</a>
       </p>
-      <p><strong>Studied at:</strong> York College of Pennsylvania</p>
+      <p class="hours"><strong>Hours:</strong> Monday - Friday 7am - 4pm<br>Closed Saturday &amp; Sunday</p>
     </footer>
   </body>
 </html>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -328,6 +328,10 @@ nav a {
   text-decoration: none;
 }
 
+.hours {
+  margin-top: 0.5em;
+}
+
 .send-button {
   background-color: #265e36;
   color: white;


### PR DESCRIPTION
## Summary
- add hours banner to contact page and each footer
- remove old school reference from footer
- provide simple styling for hours text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c6480772483269cd59269e57ad97c